### PR TITLE
Update mongoid to 5.0.0

### DIFF
--- a/lib/mailcannon/sendgrid_event.rb
+++ b/lib/mailcannon/sendgrid_event.rb
@@ -12,6 +12,6 @@ class MailCannon::SendgridEvent
   belongs_to :envelope_bag, index: true
 
   def self.insert_bulk(tha_huge_string)
-    MailCannon::SendgridEvent.with(safe: true).collection.insert(tha_huge_string)
+    MailCannon::SendgridEvent.with(safe: true).collection.insert_many(tha_huge_string)
   end
 end

--- a/mailcannon.gemspec
+++ b/mailcannon.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activemodel', '>= 3.0.0'
 
   s.add_dependency 'redis'
-  s.add_dependency 'mongoid','~> 4.0.2'
+  s.add_dependency 'mongoid','~> 5.0.0'
   s.add_dependency 'sidekiq', '2.17.7'
   s.add_dependency 'sendgrid_webapi', '0.0.3'
   s.add_dependency 'json-schema'

--- a/spec/support/mongoid.yml
+++ b/spec/support/mongoid.yml
@@ -1,6 +1,6 @@
 development:
   # Configure available database sessions. (required)
-  sessions:
+  clients:
     # Defines the default session. (required)
     default:
       # Defines the name of the default database that Mongoid can connect to.
@@ -11,7 +11,7 @@ development:
       hosts:
         - localhost:<%= ENV['MONGODB_PORT'] || '27017' %>
 test:
-  sessions:
+  clients:
     default:
       database: mailcannon_test
       hosts:


### PR DESCRIPTION
Atualização do mongoid para a versão 5.0.0, para suportar o MongoDB 3.0