### PR TITLE
[Core] Prepare mailcannon to Rails 5

### DIFF
--- a/lib/mailcannon/envelope.rb
+++ b/lib/mailcannon/envelope.rb
@@ -4,7 +4,7 @@ class MailCannon::Envelope
   include Mongoid::Timestamps
   include MailCannon::Adapter::SendgridWeb
 
-  belongs_to :envelope_bag, index: true
+  belongs_to :envelope_bag, index: true, optional: true
 
   embeds_one :mail
   embeds_many :stamps

--- a/lib/mailcannon/version.rb
+++ b/lib/mailcannon/version.rb
@@ -2,8 +2,8 @@
 module MailCannon
   module Version
     MAJOR = 0
-    MINOR = 6
-    PATCH = 2
+    MINOR = 7
+    PATCH = 0
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}".freeze
   end
 end


### PR DESCRIPTION
Prepare mailcannon gem to work with Rails 5

#### How?
In Rails 5 all `belongs_to` associations have the option `required` set to `true` by default, so we need to specify where the association isn't required by default with `optional` set to `true`

More information available [here](https://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html) and [here](https://github.com/rails/rails/pull/18937)
